### PR TITLE
CRDL-275 Implement reference data import process and reference data connectors using the CRDL cache service

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,13 @@
+version = 3.9.6
+
+runner.dialect = scala3
+
+preset = defaultWithAlign
+
+maxColumn = 100
+
+indent {
+  callSite = 2
+  defnSite = 2
+  extendSite = 2
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/config/AppConfig.scala
@@ -16,12 +16,16 @@
 
 package uk.gov.hmrc.emcstfereferencedata.config
 
+import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class AppConfig @Inject()(servicesConfig: ServicesConfig) {
+class AppConfig @Inject() (val config: Configuration, servicesConfig: ServicesConfig) {
+
+  lazy val crdlCacheUrl: String  = servicesConfig.baseUrl("crdl-cache")
+  lazy val crdlCachePath: String = config.get[String]("microservice.services.crdl-cache.path")
 
   def stubUrl(): String = servicesConfig.baseUrl("emcs-tfe-reference-data-stub")
 

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.emcstfereferencedata.connector.crdl
 
 import com.typesafe.config.Config

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnector.scala
@@ -1,0 +1,38 @@
+package uk.gov.hmrc.emcstfereferencedata.connector.crdl
+
+import com.typesafe.config.Config
+import org.apache.pekko.actor.ActorSystem
+import uk.gov.hmrc.emcstfereferencedata.config.AppConfig
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
+import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.UpstreamErrorResponse.{Upstream4xxResponse, Upstream5xxResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CrdlConnector @Inject() (config: AppConfig, httpClient: HttpClientV2)(using
+  system: ActorSystem
+) extends Retries {
+  override protected def actorSystem: ActorSystem = system
+  override protected def configuration: Config    = config.config.underlying
+
+  private val throwOnFailureReads = throwOnFailure(readEitherOf[List[CrdlCodeListEntry]])
+  private val crdlCacheUrl        = url"${config.crdlCacheUrl}/${config.crdlCachePath.split('/')}"
+
+  def fetchCodeList(
+    code: CodeListCode
+  )(using ec: ExecutionContext): Future[List[CrdlCodeListEntry]] = {
+    retryFor(s"fetch of codelist entries for ${code.value}") {
+      // No point in retrying if our request is wrong
+      case Upstream4xxResponse(_) => false
+      // Attempt to recover from intermittent connectivity issues
+      case Upstream5xxResponse(_) => true
+    } {
+      httpClient
+        .get(url"$crdlCacheUrl/${code.value}")(HeaderCarrier())
+        .execute[List[CrdlCodeListEntry]](using throwOnFailureReads, ec)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes
+
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ErrorResponse}
+import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class RetrieveAllCNCodesConnectorCRDL @Inject() (
+  repository: CnCodesRepository
+) extends RetrieveAllCNCodesConnector {
+
+  override def retrieveAllCnCodes(
+    exciseProductCode: String
+  )(using
+    ec: ExecutionContext,
+    hc: HeaderCarrier
+  ): Future[Either[ErrorResponse, Seq[CnCodeInformation]]] = {
+
+    repository
+      .fetchCnCodesForProduct(exciseProductCode)
+      .map(Right(_))
+  }
+
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
@@ -37,6 +37,9 @@ class RetrieveAllCNCodesConnectorCRDL @Inject() (
     repository
       .fetchCnCodesForProduct(exciseProductCode)
       .map(Right(_))
+      .recover { case ex =>
+        Left(ErrorResponse.UnexpectedDownstreamResponseError)
+      }
   }
 
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDL.scala
@@ -16,16 +16,18 @@
 
 package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes
 
+import play.api.Logger
 import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ErrorResponse}
 import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
 import uk.gov.hmrc.http.HeaderCarrier
-
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RetrieveAllCNCodesConnectorCRDL @Inject() (
   repository: CnCodesRepository
 ) extends RetrieveAllCNCodesConnector {
+
+  lazy val logger: Logger = Logger(this.getClass)
 
   override def retrieveAllCnCodes(
     exciseProductCode: String
@@ -37,8 +39,14 @@ class RetrieveAllCNCodesConnectorCRDL @Inject() (
     repository
       .fetchCnCodesForProduct(exciseProductCode)
       .map(Right(_))
-      .recover { case ex =>
-        Left(ErrorResponse.UnexpectedDownstreamResponseError)
+      .recover {
+        case ex => {
+          logger.warn(
+            "[RetrieveAllCnCodesConnectorCRDL][retrieveAllCnCodes] Unexpected Error fetching data from repository",
+            ex
+          )
+          Left(ErrorResponse.UnexpectedDownstreamResponseError)
+        }
       }
   }
 

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes
 
+import play.api.Logger
 import uk.gov.hmrc.emcstfereferencedata.models.response.{ErrorResponse, ExciseProductCode}
 import uk.gov.hmrc.emcstfereferencedata.repositories.ExciseProductsRepository
 import uk.gov.hmrc.http.HeaderCarrier
@@ -11,21 +28,23 @@ class RetrieveAllEPCCodesConnectorCRDL @Inject() (
   repository: ExciseProductsRepository
 ) extends RetrieveAllEPCCodesConnector {
 
+  lazy val logger: Logger = Logger(this.getClass)
+
   override def retrieveAllEPCCodes()(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
   ): Future[Either[ErrorResponse, Seq[ExciseProductCode]]] = {
     repository
       .fetchAllEPCCodes()
-      .map(Right())
-      .recover({
-        case ex: Exception => {
+      .map(Right(_))
+      .recover {
+        case exception: Exception => {
           logger.warn(
-            "[RetrieveAllEPCCodesConnectorCRDL][retrieveAllEPCCodes] Unexpected Error fetching data from repository",
-            ex
+            s"[RetrieveCnCodeInformationConnectorCRDL][retrieveCnCodeInformation] Unexpected Error fetching data from repository"
           )
+          Left(ErrorResponse.UnexpectedDownstreamResponseError)
         }
-      })
+      }
 
   }
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
@@ -1,7 +1,5 @@
 package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes
 
-
-
 import uk.gov.hmrc.emcstfereferencedata.models.response.{ErrorResponse, ExciseProductCode}
 import uk.gov.hmrc.emcstfereferencedata.repositories.ExciseProductsRepository
 import uk.gov.hmrc.http.HeaderCarrier
@@ -10,10 +8,24 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RetrieveAllEPCCodesConnectorCRDL @Inject() (
-                                                  repository: ExciseProductsRepository
-                                                ) extends RetrieveAllEPCCodesConnector{
+  repository: ExciseProductsRepository
+) extends RetrieveAllEPCCodesConnector {
 
+  override def retrieveAllEPCCodes()(implicit
+    ec: ExecutionContext,
+    hc: HeaderCarrier
+  ): Future[Either[ErrorResponse, Seq[ExciseProductCode]]] = {
+    repository
+      .fetchAllEPCCodes()
+      .map(Right())
+      .recover({
+        case ex: Exception => {
+          logger.warn(
+            "[RetrieveAllEPCCodesConnectorCRDL][retrieveAllEPCCodes] Unexpected Error fetching data from repository",
+            ex
+          )
+        }
+      })
 
-  override def retrieveAllEPCCodes()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Either[ErrorResponse, Seq[ExciseProductCode]]] =
-    ???
+  }
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
@@ -1,0 +1,19 @@
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes
+
+
+
+import uk.gov.hmrc.emcstfereferencedata.models.response.{ErrorResponse, ExciseProductCode}
+import uk.gov.hmrc.emcstfereferencedata.repositories.ExciseProductsRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class RetrieveAllEPCCodesConnectorCRDL @Inject() (
+                                                  repository: ExciseProductsRepository
+                                                ) extends RetrieveAllEPCCodesConnector{
+
+
+  override def retrieveAllEPCCodes()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Either[ErrorResponse, Seq[ExciseProductCode]]] =
+    ???
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDL.scala
@@ -40,7 +40,8 @@ class RetrieveAllEPCCodesConnectorCRDL @Inject() (
       .recover {
         case exception: Exception => {
           logger.warn(
-            s"[RetrieveCnCodeInformationConnectorCRDL][retrieveCnCodeInformation] Unexpected Error fetching data from repository"
+            "[RetrieveAllEPCCodesConnector][retrieveAllEPCCodes] Unexpected Error fetching data from repository",
+            exception
           )
           Left(ErrorResponse.UnexpectedDownstreamResponseError)
         }

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDL.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveCnCodeInformation
+
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import play.api.Logger
+import uk.gov.hmrc.emcstfereferencedata.models.request.CnInformationRequest
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ErrorResponse}
+import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class RetrieveCnCodeInformationConnectorCRDL @Inject() (
+  repository: CnCodesRepository
+) extends RetrieveCnCodeInformationConnector {
+
+  lazy val logger: Logger = Logger(this.getClass)
+
+  override def retrieveCnCodeInformation(cnInformationRequest: CnInformationRequest)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Either[ErrorResponse, Map[String, CnCodeInformation]]] =
+    repository
+      .fetchCnCodeInformation(cnInformationRequest)
+      .map(Right(_))
+      .recover {
+        case exception: Exception => {
+          logger.warn(
+            s"[RetrieveCnCodeInformationConnectorCRDL][retrieveCnCodeInformation] Unexpected Error fetching data from repository"
+          )
+          Left(ErrorResponse.UnexpectedDownstreamResponseError)
+        }
+      }
+
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDL.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDL.scala
@@ -57,7 +57,7 @@ class RetrieveCnCodeInformationConnectorCRDL @Inject() (
       .recover {
         case exception: Exception => {
           logger.warn(
-            s"[RetrieveCnCodeInformationConnectorCRDL][retrieveCnCodeInformation] Unexpected Error fetching data from repository"
+            s"[RetrieveCnCodeInformationConnectorCRDL][retrieveCnCodeInformation] Unexpected Error fetching data from repository,", exception
           )
           Left(ErrorResponse.UnexpectedDownstreamResponseError)
         }

--- a/app/uk/gov/hmrc/emcstfereferencedata/controllers/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/controllers/testonly/TestOnlyController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.controllers.testonly
+
+import org.mongodb.scala.*
+import org.mongodb.scala.model.Filters
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+
+  @Singleton
+  class TestOnlyController @Inject() (
+    cc: ControllerComponents,
+    codeListsRepository: CnCodesRepository
+  )(using ec: ExecutionContext)
+    extends BackendController(cc) {
+
+    def deleteCodeLists(): Action[AnyContent] = Action.async {
+      codeListsRepository.collection.deleteMany(Filters.empty()).toFuture().map {
+        case result if result.wasAcknowledged() => Ok
+        case _                                  => InternalServerError
+      }
+    }
+  }
+

--- a/app/uk/gov/hmrc/emcstfereferencedata/controllers/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/controllers/testonly/TestOnlyController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.emcstfereferencedata.controllers.testonly
 import org.mongodb.scala.*
 import org.mongodb.scala.model.Filters
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.emcstfereferencedata.repositories.{CnCodesRepository, ExciseProductsRepository, CodeListsRepository}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -28,12 +28,28 @@ import scala.concurrent.ExecutionContext
   @Singleton
   class TestOnlyController @Inject() (
     cc: ControllerComponents,
-    codeListsRepository: CnCodesRepository
+    codeListsRepository: CodeListsRepository,
+    exciseProductsRepository: ExciseProductsRepository,
+    cnCodesRepository: CnCodesRepository
   )(using ec: ExecutionContext)
     extends BackendController(cc) {
 
     def deleteCodeLists(): Action[AnyContent] = Action.async {
       codeListsRepository.collection.deleteMany(Filters.empty()).toFuture().map {
+        case result if result.wasAcknowledged() => Ok
+        case _                                  => InternalServerError
+      }
+    }
+    
+    def deleteExciseProducts(): Action[AnyContent] = Action.async {
+      exciseProductsRepository.collection.deleteMany(Filters.empty()).toFuture().map {
+        case result if result.wasAcknowledged() => Ok
+        case _                                  => InternalServerError
+      }
+    }
+    
+    def deleteCnCodes(): Action[AnyContent] = Action.async {
+      cnCodesRepository.collection.deleteMany(Filters.empty()).toFuture().map {
         case result if result.wasAcknowledged() => Ok
         case _                                  => InternalServerError
       }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/crdl/CodeListCode.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/crdl/CodeListCode.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfereferencedata.models.mongo
+package uk.gov.hmrc.emcstfereferencedata.models.crdl
 
 import play.api.libs.json.{Format, Json}
 
@@ -22,4 +22,8 @@ case class CodeListCode(value: String) extends AnyVal
 
 object CodeListCode {
   given Format[CodeListCode] = Json.valueFormat[CodeListCode]
+  val BC36 = CodeListCode("BC36")
+  val BC37 = CodeListCode("BC37")
+  val BC66 = CodeListCode("BC66")
+  val E200 = CodeListCode("E200")
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/crdl/CrdlCodeListEntry.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/crdl/CrdlCodeListEntry.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.models.crdl
+
+import play.api.libs.json.{JsObject, Json, Reads}
+
+case class CrdlCodeListEntry(
+  key: String,
+  value: String,
+  properties: JsObject
+)
+
+object CrdlCodeListEntry {
+  given Reads[CrdlCodeListEntry] = Json.reads[CrdlCodeListEntry]
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/errors/MongoError.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/errors/MongoError.scala
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfereferencedata.models.mongo
+package uk.gov.hmrc.emcstfereferencedata.models.errors
 
-import play.api.libs.json.{JsObject, Json, OFormat}
-import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
-
-case class CodeListEntry(
-  codeListCode: CodeListCode,
-  key: String,
-  value: String,
-  properties: JsObject
-)
-
-object CodeListEntry {
-  given format: OFormat[CodeListEntry] = Json.format[CodeListEntry]
-
-  def fromCrdlEntry(codeListCode: CodeListCode, entry: CrdlCodeListEntry): CodeListEntry =
-    CodeListEntry(codeListCode, entry.key, entry.value, entry.properties)
+enum MongoError(val message: String, val cause: Throwable = null)
+  extends Exception(message, cause) {
+  case NotAcknowledged extends MongoError("Mongo write was not acknowledged")
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListCode.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListCode.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.emcstfereferencedata.models.mongo
 
 import play.api.libs.json.{Format, Json}

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListCode.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListCode.scala
@@ -1,0 +1,9 @@
+package uk.gov.hmrc.emcstfereferencedata.models.mongo
+
+import play.api.libs.json.{Format, Json}
+
+case class CodeListCode(value: String) extends AnyVal
+
+object CodeListCode {
+  given Format[CodeListCode] = Json.valueFormat[CodeListCode]
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
@@ -1,0 +1,14 @@
+package uk.gov.hmrc.emcstfereferencedata.models.mongo
+
+import play.api.libs.json.{JsObject, Json, OFormat}
+
+case class CodeListEntry(
+  codeListCode: CodeListCode,
+  key: String,
+  value: String,
+  properties: JsObject
+)
+
+object CodeListEntry {
+  given OFormat[CodeListEntry] = Json.format[CodeListEntry]
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.emcstfereferencedata.models.mongo
 
 import play.api.libs.json.{JsObject, Json, OFormat}
-import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
 
 case class CodeListEntry(
   codeListCode: CodeListCode,

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/mongo/CodeListEntry.scala
@@ -1,6 +1,7 @@
 package uk.gov.hmrc.emcstfereferencedata.models.mongo
 
 import play.api.libs.json.{JsObject, Json, OFormat}
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
 
 case class CodeListEntry(
   codeListCode: CodeListCode,
@@ -10,5 +11,8 @@ case class CodeListEntry(
 )
 
 object CodeListEntry {
-  given OFormat[CodeListEntry] = Json.format[CodeListEntry]
+  given format: OFormat[CodeListEntry] = Json.format[CodeListEntry]
+
+  def fromCrdlEntry(codeListCode: CodeListCode, entry: CrdlCodeListEntry): CodeListEntry =
+    CodeListEntry(codeListCode, entry.key, entry.value, entry.properties)
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeInformation.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/CnCodeInformation.scala
@@ -32,6 +32,8 @@ object CnCodeInformation {
     "unitOfMeasureCode" -> o.unitOfMeasureCode
   )
 
+  val mongoFormat: OFormat[CnCodeInformation] = Json.format[CnCodeInformation]
+
   implicit val mapReads: Reads[Map[String, CnCodeInformation]] = {
     case JsObject(underlying) => JsSuccess(underlying.map {
       case (k, v) => k -> v.as[CnCodeInformation]

--- a/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductCode.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/models/response/ExciseProductCode.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.emcstfereferencedata.models.response
 
-import play.api.libs.json.{Json, Reads, OWrites}
+import play.api.libs.json.{Json, OFormat, OWrites, Reads}
 import uk.gov.hmrc.emcstfereferencedata.utils.StringUtils
 
 case class ExciseProductCode(code: String, description: String, category: String, categoryDescription: String)
@@ -31,4 +31,6 @@ object ExciseProductCode {
     "category" -> o.category,
     "categoryDescription" -> StringUtils.removeHtmlEscapedCharactersAndAddSmartQuotes(o.categoryDescription)
   )
+
+  val mongoFormat: OFormat[ExciseProductCode] = Json.format[ExciseProductCode]
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepository.scala
@@ -38,10 +38,11 @@ class CnCodesRepository @Inject() (val mongoComponent: MongoComponent)(using
     domainFormat = CnCodeInformation.mongoFormat,
     indexes = Seq(
       IndexModel(
-        Indexes.ascending("cnCode"),
+        // A CN code can belong to multiple excise products,
+        // and an excise product can be associated with multiple CN codes.
+        Indexes.ascending("exciseProductCode", "cnCode"),
         IndexOptions().unique(true)
-      ),
-      IndexModel(Indexes.ascending("exciseProductCode"))
+      )
     )
   )
   with Transactions {

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.*
 import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.errors.MongoError
 import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
-import uk.gov.hmrc.emcstfereferencedata.models.response.ExciseProductCode
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 import uk.gov.hmrc.mongo.transaction.Transactions
@@ -43,11 +43,14 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
     domainFormat = CodeListEntry.format,
     extraCodecs =
       Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
-        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)) :+
-        Codecs.playFormatCodec(ExciseProductCode.mongoFormat),
+        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)) ++
+        Seq(
+          Codecs.playFormatCodec(ExciseProductCode.mongoFormat),
+          Codecs.playFormatCodec(CnCodeInformation.mongoFormat)
+        ),
     indexes = Seq(
       IndexModel(
-        Indexes.ascending("codeListCode", "key"),
+        Indexes.ascending("codeListCode", "key", "value"),
         IndexOptions().unique(true)
       ),
       IndexModel(Indexes.ascending("codeListCode"))
@@ -58,8 +61,98 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
   // This collection's entries are cleared every time new codelists are imported
   override lazy val requiresTtlIndex: Boolean = false
 
-  private val ExciseProducts    = "BC36"
-  private val ProductCategories = "BC66"
+  private val ExciseProducts                    = "BC36"
+  private val CnCodes                           = "BC37"
+  private val ProductCategories                 = "BC66"
+  private val CnCodeExciseProductCorrespondence = "E200"
+
+  private def lookupIn(
+    codeListCode: String,
+    localField: String,
+    foreignField: String,
+    alias: String
+  ) =
+    lookup(
+      from = "codeLists",
+      // Alias the local field as `alias`
+      let = Seq(Variable(alias, "$" + localField)),
+      pipeline = Seq(
+        filter(
+          expr(
+            BsonDocument(
+              "$and" -> BsonArray(
+                // Match the codelist code
+                BsonDocument("$eq" -> BsonArray("$codeListCode", codeListCode)),
+                // Find the one where the foreign field is equal to the local field
+                BsonDocument("$eq" -> BsonArray("$" + foreignField, "$$" + alias))
+              )
+            )
+          )
+        )
+      ),
+      // Project the result as `alias`
+      as = alias
+    )
+
+  private def toInt(bson: BsonDocument) =
+    BsonDocument("$toInt" -> bson)
+
+  private def getFieldOf(fieldPath: String, arrayField: String) = {
+    val segments      = fieldPath.split('.')
+    val firstArrayDoc = BsonDocument("$first" -> ("$" + arrayField))
+    segments.foldLeft(firstArrayDoc) { case (bson, field) =>
+      BsonDocument("$getField" -> BsonDocument("field" -> field, "input" -> bson))
+    }
+  }
+
+  def buildCnCodes(session: ClientSession): Future[Seq[CnCodeInformation]] = {
+    collection
+      .aggregate[CnCodeInformation](
+        session,
+        List(
+          // Find the CN code <-> excise product mappings
+          filter(equal("codeListCode", CnCodeExciseProductCorrespondence)),
+          // Look up the CN code for this mapping's key
+          lookupIn(
+            codeListCode = CnCodes,
+            localField = "key",
+            foreignField = "key",
+            alias = "cnCode"
+          ),
+          // Look up the excise product for this mapping's value
+          lookupIn(
+            codeListCode = ExciseProducts,
+            localField = "value",
+            foreignField = "key",
+            alias = "exciseProduct"
+          ),
+          project(
+            fields(
+              // Include the mapping's key as "cnCode"
+              computed("cnCode", "$key"),
+              computed(
+                "cnCodeDescription",
+                // Get the "cnCodeDescription" from the nested "cnCode" doc's value
+                getFieldOf("value", arrayField = "cnCode")
+              ),
+              // Include the mapping's value as "exciseProductCode"
+              computed("exciseProductCode", "$value"),
+              computed(
+                "exciseProductCodeDescription",
+                // Get the "exciseProductCodeDescription" from the nested "exciseProduct" doc's value
+                getFieldOf("value", arrayField = "exciseProduct")
+              ),
+              computed(
+                "unitOfMeasureCode",
+                // Get the "unitOfMeasureCode" from the nested "exciseProduct" doc's properties.unitOfMeasureCode
+                toInt(getFieldOf("properties.unitOfMeasureCode", arrayField = "exciseProduct"))
+              )
+            )
+          )
+        )
+      )
+      .toFuture()
+  }
 
   def buildExciseProducts(session: ClientSession): Future[Seq[ExciseProductCode]] = {
     collection
@@ -68,26 +161,11 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
         List(
           // Find the excise products
           filter(equal("codeListCode", ExciseProducts)),
-          lookup(
-            from = "codeLists",
-            // Alias the excise product category to "category"
-            let = Seq(Variable("category", "$properties.exciseProductsCategoryCode")),
-            pipeline = Seq(
-              filter(
-                expr(
-                  BsonDocument(
-                    "$and" -> BsonArray(
-                      // Find the product categories
-                      BsonDocument("$eq" -> BsonArray("$codeListCode", ProductCategories)),
-                      // Find the one where the category is equal to the outer document's category
-                      BsonDocument("$eq" -> BsonArray("$key", "$$category"))
-                    )
-                  )
-                )
-              )
-            ),
-            // Project the result as productCategory
-            as = "productCategory"
+          lookupIn(
+            codeListCode = ProductCategories,
+            localField = "properties.exciseProductsCategoryCode",
+            foreignField = "key",
+            alias = "productCategory"
           ),
           project(
             fields(
@@ -98,22 +176,12 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
               computed(
                 // Get the "category" from the nested "productCategory" doc's key
                 "category",
-                BsonDocument(
-                  "$getField" -> BsonDocument(
-                    "field" -> "key",
-                    "input" -> BsonDocument("$first" -> "$productCategory")
-                  )
-                )
+                getFieldOf("key", arrayField = "productCategory")
               ),
               computed(
                 // Get the "categoryDescription" from the nested "productCategory" doc's value
                 "categoryDescription",
-                BsonDocument(
-                  "$getField" -> BsonDocument(
-                    "field" -> "value",
-                    "input" -> BsonDocument("$first" -> "$productCategory")
-                  )
-                )
+                getFieldOf("value", arrayField = "productCategory")
               )
             )
           )

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -1,0 +1,46 @@
+package uk.gov.hmrc.emcstfereferencedata.repositories
+
+import org.mongodb.scala.*
+import org.mongodb.scala.model.Filters.*
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
+import play.api.libs.json.{Format, JsBoolean, JsValue, Reads, Writes}
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
+import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import uk.gov.hmrc.mongo.transaction.Transactions
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using ec: ExecutionContext)
+  extends PlayMongoRepository[CodeListEntry](
+    mongoComponent,
+    collectionName = "codelists",
+    domainFormat = CodeListEntry.format,
+    extraCodecs =
+      Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
+        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
+    indexes = Seq(
+      IndexModel(
+        Indexes.ascending("codeListCode", "key"),
+        IndexOptions().unique(true)
+      )
+    )
+  ) with Transactions {
+
+  // This collection's entries are cleared every time new codelists are imported
+  override lazy val requiresTtlIndex: Boolean = false
+
+  def saveCodeListEntries(
+    session: ClientSession,
+    codeListCode: CodeListCode,
+    crdlEntries: List[CrdlCodeListEntry]
+  ): Future[Unit] =
+    for {
+      _ <- collection.deleteMany(session, equal("codeListCode", codeListCode.value)).toFuture()
+      entries = crdlEntries.map(CodeListEntry.fromCrdlEntry(codeListCode, _))
+      _ <- collection.insertMany(session, entries).toFuture()
+    } yield ()
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -123,7 +123,7 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
   }
 
   // TODO: Make public when implementing test-only endpoints
-  private def deleteCodeListEntries(
+  def deleteCodeListEntries(
     session: ClientSession,
     codeListCode: Option[CodeListCode]
   ): Future[Unit] =

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -121,8 +121,6 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
       )
       .toFuture()
   }
-
-  // TODO: Make public when implementing test-only endpoints
   def deleteCodeListEntries(
     session: ClientSession,
     codeListCode: Option[CodeListCode]

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepository.scala
@@ -24,9 +24,9 @@ import org.mongodb.scala.model.Filters.*
 import org.mongodb.scala.model.Projections.*
 import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import play.api.libs.json.*
-import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
 import uk.gov.hmrc.emcstfereferencedata.models.errors.MongoError
-import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
+import uk.gov.hmrc.emcstfereferencedata.models.mongo.CodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
@@ -189,6 +189,7 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using e
       )
       .toFuture()
   }
+
   def deleteCodeListEntries(
     session: ClientSession,
     codeListCode: Option[CodeListCode]

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
@@ -58,6 +58,18 @@ class ExciseProductsRepository @Inject() (val mongoComponent: MongoComponent)(us
           throw MongoError.NotAcknowledged
       }
 
+  def saveExciseProducts(
+    session: ClientSession,
+    exciseProducts: List[ExciseProductCode]
+  ): Future[Unit] =
+    for {
+      _ <- deleteExciseProducts(session)
+      _ <- collection.insertMany(session, exciseProducts).toFuture().map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+    } yield ()
+
   def fetchExciseProductsForCategory(categoryCode: String): Future[Seq[ExciseProductCode]] =
     collection
       .find(equal("category", categoryCode))

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.repositories
+
+import org.mongodb.scala.*
+import org.mongodb.scala.model.Filters.*
+import org.mongodb.scala.model.Sorts.ascending
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
+import uk.gov.hmrc.emcstfereferencedata.models.errors.MongoError
+import uk.gov.hmrc.emcstfereferencedata.models.response.ExciseProductCode
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.transaction.Transactions
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ExciseProductsRepository @Inject() (val mongoComponent: MongoComponent)(using
+  ec: ExecutionContext
+) extends PlayMongoRepository[ExciseProductCode](
+    mongoComponent,
+    collectionName = "exciseProducts",
+    domainFormat = ExciseProductCode.mongoFormat,
+    indexes = Seq(
+      IndexModel(
+        Indexes.ascending("code"),
+        IndexOptions().unique(true)
+      ),
+      IndexModel(Indexes.ascending("category"))
+    )
+  )
+  with Transactions {
+
+  // This collection's entries are cleared every time new codelists are imported
+  override lazy val requiresTtlIndex: Boolean = false
+
+  def deleteExciseProducts(session: ClientSession): Future[Unit] =
+    collection
+      .deleteMany(session, empty())
+      .toFuture()
+      .map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+
+  def fetchExciseProductsForCategory(categoryCode: String): Future[Seq[ExciseProductCode]] =
+    collection
+      .find(equal("category", categoryCode))
+      .sort(ascending("code"))
+      .toFuture()
+}

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
@@ -76,7 +76,9 @@ class ExciseProductsRepository @Inject() (val mongoComponent: MongoComponent)(us
       .sort(ascending("code"))
       .toFuture()
 
-  def fetchAllEPCCodes(): Future[Seq[ExciseProductCode]] = ???
-
-
+  def fetchAllEPCCodes(): Future[Seq[ExciseProductCode]] =
+    collection
+      .find()
+      .sort(ascending("code"))
+      .toFuture()
 }

--- a/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepository.scala
@@ -75,4 +75,8 @@ class ExciseProductsRepository @Inject() (val mongoComponent: MongoComponent)(us
       .find(equal("category", categoryCode))
       .sort(ascending("code"))
       .toFuture()
+
+  def fetchAllEPCCodes(): Future[Seq[ExciseProductCode]] = ???
+
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ lazy val it = project
     libraryDependencies ++= AppDependencies.it,
     // Change classloader layering to avert classloading issues
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
+    // Disable duplicate compiler option warning as it's caused by our sbt plugins
+    scalacOptions += "-Wconf:msg=Flag.*repeatedly:s",
     // Uncomment to disable Oracle tests
     // Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,6 @@ lazy val it = project
     // Disable duplicate compiler option warning as it's caused by our sbt plugins
     scalacOptions += "-Wconf:msg=Flag.*repeatedly:s",
     // Uncomment to disable Oracle tests
-    // Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb")
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb")
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,4 +26,6 @@ lazy val it = project
   .dependsOn(microservice % "test->test") // the "test->test" allows reusing test code and test dependencies
   .settings(DefaultBuildSettings.itSettings())
   .settings(libraryDependencies ++= AppDependencies.it)
+  // Uncomment to disable Oracle tests
+  //.settings(Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ lazy val microservice = (project in file("."))
     name := appName,
     libraryDependencies ++= AppDependencies(),
     PlayKeys.playDefaultPort := 8312,
+    // Change classloader layering to avert classloading issues
+    Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
     // suppress warnings in generated routes files
     scalacOptions ++= Seq(
@@ -25,7 +27,11 @@ lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test") // the "test->test" allows reusing test code and test dependencies
   .settings(DefaultBuildSettings.itSettings())
-  .settings(libraryDependencies ++= AppDependencies.it)
-  // Uncomment to disable Oracle tests
-  //.settings(Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb"))
+  .settings(
+    libraryDependencies ++= AppDependencies.it,
+    // Change classloader layering to avert classloading issues
+    Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
+    // Uncomment to disable Oracle tests
+    // Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "uk.gov.hmrc.emcstfereferencedata.support.OracleDb")
+  )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,6 +28,8 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandl
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.emcstfereferencedata.config.Module"
 
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
+
 # Auth Module
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
@@ -60,7 +62,9 @@ controllers {
 }
 
 # Microservice specific config
-
+mongodb {
+  uri = "mongodb://localhost:27017/emcs-tfe-reference-data"
+}
 
 microservice {
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,6 +74,13 @@ microservice {
       port = 8500
     }
 
+    crdl-cache {
+      protocol = http
+      host = localhost
+      port = 7252
+      path = "crdl-cache/lists"
+    }
+
     emcs-tfe-reference-data-stub {
       protocol = http
       host = localhost

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,6 +12,6 @@
 # Add all the application routes to the prod.routes file
 ->        /        prod.Routes
 
-DELETE        /emcstfereferencedata/test-only/codelists                      uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
-DELETE        /emcstfereferencedata/test-only/deleteexciseproducts           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
-DELETE        /emcstfereferencedata/test-only/deletecncodes                  uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()
+DELETE        /emcstfereferencedata/test-only/deletecodelists               uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
+DELETE        /emcstfereferencedata/test-only/deleteexciseproducts          uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
+DELETE        /emcstfereferencedata/test-only/deletecncodes                 uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,5 @@
 
 # Add all the application routes to the prod.routes file
 ->        /        prod.Routes
+
+DELETE        /emcstfereferencedata/test-only/codelists           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,6 +12,6 @@
 # Add all the application routes to the prod.routes file
 ->        /        prod.Routes
 
-DELETE        /emcstfereferencedata/test-only/deletecodelists               uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
-DELETE        /emcstfereferencedata/test-only/deleteexciseproducts          uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
-DELETE        /emcstfereferencedata/test-only/deletecncodes                 uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()
+DELETE        /emcs-tfe-reference-data/test-only/codelists               uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
+DELETE        /emcs-tfe-reference-data/test-only/excise-products          uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
+DELETE        /emcs-tfe-reference-data/test-only/cn-codes                 uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,4 +12,6 @@
 # Add all the application routes to the prod.routes file
 ->        /        prod.Routes
 
-DELETE        /emcstfereferencedata/test-only/codelists           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
+DELETE        /emcstfereferencedata/test-only/codelists                      uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCodeLists()
+DELETE        /emcstfereferencedata/test-only/deleteexciseproducts           uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteExciseProducts()
+DELETE        /emcstfereferencedata/test-only/deletecncodes                  uk.gov.hmrc.emcstfereferencedata.controllers.testonly.TestOnlyController.deleteCnCodes()

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnectorSpec.scala
@@ -1,0 +1,157 @@
+package uk.gov.hmrc.emcstfereferencedata.connector.crdl
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import play.api.Configuration
+import play.api.http.{ContentTypes, HeaderNames}
+import play.api.libs.json.{Json, Writes}
+import uk.gov.hmrc.emcstfereferencedata.config.AppConfig
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.ExecutionContext
+
+class CrdlConnectorSpec
+  extends AsyncWordSpec
+  with Matchers
+  with WireMockSupport
+  with HttpClientV2Support
+  with EitherValues {
+
+  given actorSystem: ActorSystem  = ActorSystem("test")
+  given ExecutionContext          = actorSystem.dispatcher
+  given Writes[CrdlCodeListEntry] = Json.writes[CrdlCodeListEntry]
+
+  private val config = Configuration(
+    "microservice.services.crdl-cache.host" -> "localhost",
+    "microservice.services.crdl-cache.path" -> "crdl-cache/lists",
+    "microservice.services.crdl-cache.port" -> wireMockPort,
+    "http-verbs.retries.intervals"          -> List("1.millis")
+  )
+
+  private val appConfig = AppConfig(config, ServicesConfig(config))
+
+  private val connector = new CrdlConnector(appConfig, httpClientV2)
+
+  private val exciseProductCategories = List(
+    CrdlCodeListEntry(
+      key = "B",
+      value = "Beer",
+      properties = Json.obj("actionIdentification" -> "1084")
+    ),
+    CrdlCodeListEntry(
+      key = "E",
+      value = "Energy Products",
+      properties = Json.obj("actionIdentification" -> "1085")
+    ),
+    CrdlCodeListEntry(
+      key = "I",
+      value = "Intermediate products",
+      properties = Json.obj("actionIdentification" -> "1086")
+    ),
+    CrdlCodeListEntry(
+      key = "S",
+      value = "Ethyl alcohol and spirits",
+      properties = Json.obj("actionIdentification" -> "1087")
+    ),
+    CrdlCodeListEntry(
+      key = "T",
+      value = "Manufactured tobacco products",
+      properties = Json.obj("actionIdentification" -> "1088")
+    ),
+    CrdlCodeListEntry(
+      key = "W",
+      value = "Wine and fermented beverages other than wine and beer",
+      properties = Json.obj("actionIdentification" -> "1089")
+    )
+  )
+
+  "CrdlConnectorSpec.fetchCodeList" should {
+    "return codelist entries when given the code for a codelist" in {
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_TYPE, ContentTypes.JSON)
+              .withBody(Json.stringify(Json.toJson(exciseProductCategories)))
+          )
+      )
+
+      connector
+        .fetchCodeList(CodeListCode.BC66)
+        .map(_ shouldBe exciseProductCategories)
+    }
+
+    "retry issuing the request when the upstream service returns a server error" in {
+      val retrySuccess = "RetrySuccess"
+      val failedState  = "Failed"
+
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .inScenario(retrySuccess)
+          .whenScenarioStateIs(Scenario.STARTED)
+          .willReturn(serverError())
+          .willSetStateTo(failedState)
+      )
+
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .inScenario(retrySuccess)
+          .whenScenarioStateIs(failedState)
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_TYPE, ContentTypes.JSON)
+              .withBody(Json.stringify(Json.toJson(exciseProductCategories)))
+          )
+      )
+
+      connector
+        .fetchCodeList(CodeListCode.BC66)
+        .map(_ shouldBe exciseProductCategories)
+    }
+
+    "rethrow the error when the maximum number of retries has been exceeded" in {
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .willReturn(serverError())
+      )
+
+      recoverToSucceededIf[UpstreamErrorResponse] {
+        connector.fetchCodeList(CodeListCode.BC66)
+      }
+    }
+
+    "rethrow the error without retries when the upstream service returns a client error" in {
+      val shouldNotRetry = "ShouldNotRetry"
+      val failedState    = "Failed"
+
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .inScenario(shouldNotRetry)
+          .willReturn(badRequest())
+          .willSetStateTo(failedState)
+      )
+
+      stubFor(
+        get(urlPathEqualTo("/crdl-cache/lists/BC66"))
+          .inScenario(shouldNotRetry)
+          .whenScenarioStateIs(failedState)
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_TYPE, ContentTypes.JSON)
+              .withBody(Json.stringify(Json.toJson(exciseProductCategories)))
+          )
+      )
+
+      recoverToSucceededIf[UpstreamErrorResponse] {
+        connector.fetchCodeList(CodeListCode.BC66)
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/connector/crdl/CrdlConnectorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.emcstfereferencedata.connector.crdl
 
 import com.github.tomakehurst.wiremock.client.WireMock.*

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.repositories
+
+import org.mongodb.scala.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.response.CnCodeInformation
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import scala.concurrent.ExecutionContext
+
+class CnCodesRepositorySpec
+  extends AnyWordSpec
+  with DefaultPlayMongoRepositorySupport[CnCodeInformation]
+  with Matchers
+  with ScalaFutures
+  with BaseFixtures
+  with Transactions {
+
+  given TransactionConfiguration = TransactionConfiguration.strict
+  given ec: ExecutionContext     = ExecutionContext.global
+
+  override protected val repository: CnCodesRepository =
+    new CnCodesRepository(mongoComponent)
+
+  private val testCnCodes = List(testCnCodeInformation1, testCnCodeInformation2)
+
+  "CnCodesRepository.fetchCnCodesForProduct" should {
+    "return matching CN codes for a given excise product code" in {
+      repository.collection.insertMany(testCnCodes).toFuture().futureValue
+
+      repository
+        .fetchCnCodesForProduct("T400")
+        .futureValue should contain only testCnCodeInformation1
+
+      repository
+        .fetchCnCodesForProduct("S500")
+        .futureValue should contain only testCnCodeInformation2
+    }
+  }
+
+  "CnCodesRepository.deleteCnCodes" should {
+    "delete all CN code information from the underlying collection" in {
+      repository.collection.insertMany(testCnCodes).toFuture().futureValue
+
+      withSessionAndTransaction(repository.deleteCnCodes).futureValue
+      repository.fetchCnCodesForProduct("T400").futureValue shouldBe empty
+      repository.fetchCnCodesForProduct("S500").futureValue shouldBe empty
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
@@ -87,4 +87,17 @@ class CnCodesRepositorySpec
       repository.fetchCnCodesForProduct("S500").futureValue shouldBe empty
     }
   }
+
+  "CnCodesRepository.fetchCnCodeInformation" should {
+    "return a Map of CnCode to CnCodeInformation that corresponds to the provided request" in {
+      repository.collection.insertMany(testCnCodes).toFuture().futureValue
+
+      repository
+        .fetchCnCodeInformation(testCnCodeInformationRequest)
+        .futureValue should contain only Map(
+        testCnCode1 -> testCnCodeInformationItem1,
+        testCnCode2 -> testCnCodeInformation2
+      )
+    }
+  }
 }

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
@@ -94,10 +94,24 @@ class CnCodesRepositorySpec
 
       repository
         .fetchCnCodeInformation(testCnCodeInformationRequest)
-        .futureValue should contain only Map(
-        testCnCode1 -> testCnCodeInformationItem1,
+        .futureValue shouldBe Map(
+        testCnCode1 -> testCnCodeInformation1,
         testCnCode2 -> testCnCodeInformation2
       )
     }
+
+    "return all the objects that are requested" in {
+      repository.collection.insertMany(testCnCodes).toFuture().futureValue
+      
+      val requestItems: Int = testCnCodeInformationRequest.items.length
+      val resultSize: Int =
+        repository
+          .fetchCnCodeInformation(testCnCodeInformationRequest)
+          .futureValue
+          .size
+
+      requestItems shouldBe resultSize
+    }
+
   }
 }

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CnCodesRepositorySpec.scala
@@ -41,7 +41,14 @@ class CnCodesRepositorySpec
   override protected val repository: CnCodesRepository =
     new CnCodesRepository(mongoComponent)
 
-  private val testCnCodes = List(testCnCodeInformation1, testCnCodeInformation2)
+  private val testCnCodes = List(
+    testCnCodeInformation1,
+    testCnCodeInformation2,
+    testCnCodeInformation3,
+    testCnCodeInformation4,
+    testCnCodeInformation5,
+    testCnCodeInformation6
+  )
 
   "CnCodesRepository.fetchCnCodesForProduct" should {
     "return matching CN codes for a given excise product code" in {
@@ -54,6 +61,20 @@ class CnCodesRepositorySpec
       repository
         .fetchCnCodesForProduct("S500")
         .futureValue should contain only testCnCodeInformation2
+
+      repository
+        .fetchCnCodesForProduct("E430")
+        .futureValue should contain theSameElementsAs List(
+        testCnCodeInformation3,
+        testCnCodeInformation5
+      )
+
+      repository
+        .fetchCnCodesForProduct("E440")
+        .futureValue should contain theSameElementsAs List(
+        testCnCodeInformation4,
+        testCnCodeInformation6
+      )
     }
   }
 

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
 import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.emcstfereferencedata.models.response.ExciseProductCode
-import uk.gov.hmrc.mongo.MongoUtils
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
@@ -45,31 +44,6 @@ class CodeListsRepositorySpec
   override protected val repository: CodeListsRepository =
     new CodeListsRepository(mongoComponent)
 
-  private val productsRepository: ExciseProductsRepository =
-    new ExciseProductsRepository(mongoComponent)
-
-  override protected def ensureIndexes(): Seq[String] = {
-    MongoUtils.ensureIndexes(repository.collection, indexes, replaceIndexes = false).futureValue
-
-    MongoUtils
-      .ensureIndexes(
-        productsRepository.collection,
-        productsRepository.indexes,
-        replaceIndexes = false
-      )
-      .futureValue
-  }
-
-  override protected def ensureSchemas(): Unit = {
-    MongoUtils.ensureSchema(mongoComponent, repository.collection, optSchema).futureValue
-    MongoUtils.ensureSchema(mongoComponent, productsRepository.collection, productsRepository.optSchema).futureValue
-  }
-
-  override protected def prepareDatabase(): Unit = {
-    productsRepository.initialised.futureValue
-    super.prepareDatabase()
-  }
-
   "CodeListsRepository" should {
     "save entries from the countries codelist" in {
       val codeListCode = CodeListCode("BC08")
@@ -85,7 +59,7 @@ class CodeListsRepositorySpec
       val expectedEntries = crdlEntries.map(CodeListEntry.fromCrdlEntry(codeListCode, _))
       val insertedEntries = repository.collection.find().toFuture().futureValue
 
-      insertedEntries should contain allElementsOf expectedEntries
+      insertedEntries should contain theSameElementsAs expectedEntries
     }
 
     "remove previous entries when a new list of entries is saved" in {
@@ -128,7 +102,7 @@ class CodeListsRepositorySpec
       val expectedEntries = newCrdlEntries.map(CodeListEntry.fromCrdlEntry(codeListCode, _))
       val insertedEntries = repository.collection.find().toFuture().futureValue
 
-      insertedEntries should contain allElementsOf expectedEntries
+      insertedEntries should contain theSameElementsAs expectedEntries
     }
 
     "combine together entries of the excise products and product categories codelists" in {

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -22,8 +22,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
-import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
-import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
+import uk.gov.hmrc.emcstfereferencedata.models.crdl.{CodeListCode, CrdlCodeListEntry}
+import uk.gov.hmrc.emcstfereferencedata.models.mongo.CodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -24,6 +24,8 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
 import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
+import uk.gov.hmrc.emcstfereferencedata.models.response.ExciseProductCode
+import uk.gov.hmrc.mongo.MongoUtils
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
@@ -42,6 +44,31 @@ class CodeListsRepositorySpec
 
   override protected val repository: CodeListsRepository =
     new CodeListsRepository(mongoComponent)
+
+  private val productsRepository: ExciseProductsRepository =
+    new ExciseProductsRepository(mongoComponent)
+
+  override protected def ensureIndexes(): Seq[String] = {
+    MongoUtils.ensureIndexes(repository.collection, indexes, replaceIndexes = false).futureValue
+
+    MongoUtils
+      .ensureIndexes(
+        productsRepository.collection,
+        productsRepository.indexes,
+        replaceIndexes = false
+      )
+      .futureValue
+  }
+
+  override protected def ensureSchemas(): Unit = {
+    MongoUtils.ensureSchema(mongoComponent, repository.collection, optSchema).futureValue
+    MongoUtils.ensureSchema(mongoComponent, productsRepository.collection, productsRepository.optSchema).futureValue
+  }
+
+  override protected def prepareDatabase(): Unit = {
+    productsRepository.initialised.futureValue
+    super.prepareDatabase()
+  }
 
   "CodeListsRepository" should {
     "save entries from the countries codelist" in {
@@ -102,6 +129,92 @@ class CodeListsRepositorySpec
       val insertedEntries = repository.collection.find().toFuture().futureValue
 
       insertedEntries should contain allElementsOf expectedEntries
+    }
+
+    "combine together entries of the excise products and product categories codelists" in {
+      val productsCode   = CodeListCode("BC36")
+      val categoriesCode = CodeListCode("BC66")
+
+      val codeListEntries = Seq(
+        CodeListEntry(
+          categoriesCode,
+          "B",
+          "Beer",
+          Json.obj("actionIdentification" -> "1084")
+        ),
+        CodeListEntry(
+          categoriesCode,
+          "E",
+          "Energy Products",
+          Json.obj("actionIdentification" -> "1085")
+        ),
+        CodeListEntry(
+          productsCode,
+          "B000",
+          "Beer",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "3",
+            "degreePlatoApplicabilityFlag"       -> true,
+            "actionIdentification"               -> "1090",
+            "exciseProductsCategoryCode"         -> "B",
+            "alcoholicStrengthApplicabilityFlag" -> true,
+            "densityApplicabilityFlag"           -> false
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E300",
+          "Mineral oils Products falling within CN codes 2707 10, 2707 20, 2707 30 and 2707 50 (Article 20(1)(b))",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1092",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E460",
+          "Kerosene, marked falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1098",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        )
+      )
+
+      val expectedExciseProducts = List(
+        ExciseProductCode(
+          "B000",
+          "Beer",
+          "B",
+          "Beer"
+        ),
+        ExciseProductCode(
+          "E300",
+          "Mineral oils Products falling within CN codes 2707 10, 2707 20, 2707 30 and 2707 50 (Article 20(1)(b))",
+          "E",
+          "Energy Products"
+        ),
+        ExciseProductCode(
+          "E460",
+          "Kerosene, marked falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          "E",
+          "Energy Products"
+        )
+      )
+
+      repository.collection.insertMany(codeListEntries).toFuture().futureValue
+
+      val exciseProducts = withClientSession(repository.buildExciseProducts).futureValue
+
+      exciseProducts should contain theSameElementsAs expectedExciseProducts
     }
   }
 }

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
 import uk.gov.hmrc.emcstfereferencedata.models.crdl.CrdlCodeListEntry
 import uk.gov.hmrc.emcstfereferencedata.models.mongo.{CodeListCode, CodeListEntry}
-import uk.gov.hmrc.emcstfereferencedata.models.response.ExciseProductCode
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
@@ -103,6 +103,253 @@ class CodeListsRepositorySpec
       val insertedEntries = repository.collection.find().toFuture().futureValue
 
       insertedEntries should contain theSameElementsAs expectedEntries
+    }
+
+    "combine together entries of the CN codes and excise products codelists using the CN code <-> excise products correspondence" in {
+      val productsCode                = CodeListCode("BC36")
+      val cnCodesCode                 = CodeListCode("BC37")
+      val cnCodesToExciseProductsCode = CodeListCode("E200")
+
+      val codeListEntries = Seq(
+        // CN Codes <-> Excise Products
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22060059",
+          "B000",
+          Json.obj("actionIdentification" -> "355")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22060059",
+          "I000",
+          Json.obj("actionIdentification" -> "526")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22060059",
+          "S200",
+          Json.obj("actionIdentification" -> "561")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "22060059",
+          "W200",
+          Json.obj("actionIdentification" -> "711")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "27101925",
+          "E450",
+          Json.obj("actionIdentification" -> "441")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "27101925",
+          "E460",
+          Json.obj("actionIdentification" -> "443")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "27101944",
+          "E430",
+          Json.obj("actionIdentification" -> "2412")
+        ),
+        CodeListEntry(
+          cnCodesToExciseProductsCode,
+          "27101944",
+          "E440",
+          Json.obj("actionIdentification" -> "2413")
+        ),
+        // CN Codes
+        CodeListEntry(
+          cnCodesCode,
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          Json.obj("actionIdentification" -> "323")
+        ),
+        CodeListEntry(
+          cnCodesCode,
+          "27101925",
+          "Other kerosene",
+          Json.obj("actionIdentification" -> "153")
+        ),
+        CodeListEntry(
+          cnCodesCode,
+          "27101944",
+          "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+          Json.obj("actionIdentification" -> "351")
+        ),
+        // Excise Products
+        CodeListEntry(
+          productsCode,
+          "B000",
+          "Beer",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "3",
+            "degreePlatoApplicabilityFlag"       -> true,
+            "actionIdentification"               -> "1090",
+            "exciseProductsCategoryCode"         -> "B",
+            "alcoholicStrengthApplicabilityFlag" -> true,
+            "densityApplicabilityFlag"           -> false
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E430",
+          "Gasoil, unmarked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1095",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E440",
+          "Gasoil, marked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1096",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E450",
+          "Kerosene, falling within CN code 2710 19 21 and unmarked kerosene falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1097",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "E460",
+          "Kerosene, marked falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "2",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1098",
+            "exciseProductsCategoryCode"         -> "E",
+            "alcoholicStrengthApplicabilityFlag" -> false,
+            "densityApplicabilityFlag"           -> true
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "I000",
+          "Intermediate products",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "3",
+            "degreePlatoApplicabilityFlag"       -> true,
+            "actionIdentification"               -> "1109",
+            "exciseProductsCategoryCode"         -> "I",
+            "alcoholicStrengthApplicabilityFlag" -> true,
+            "densityApplicabilityFlag"           -> false
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "S200",
+          "Spirituous beverages",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "3",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1110",
+            "exciseProductsCategoryCode"         -> "S",
+            "alcoholicStrengthApplicabilityFlag" -> true,
+            "densityApplicabilityFlag"           -> false
+          )
+        ),
+        CodeListEntry(
+          productsCode,
+          "W200",
+          "Still wine and still fermented beverages other than wine and beer",
+          Json.obj(
+            "unitOfMeasureCode"                  -> "3",
+            "degreePlatoApplicabilityFlag"       -> false,
+            "actionIdentification"               -> "1119",
+            "exciseProductsCategoryCode"         -> "W",
+            "alcoholicStrengthApplicabilityFlag" -> true,
+            "densityApplicabilityFlag"           -> false
+          )
+        )
+      )
+
+      val expectedCnCodes = List(
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "B000",
+          "Beer",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "I000",
+          "Intermediate products",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "S200",
+          "Spirituous beverages",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "22060059",
+          "Other still fermented beverages in containers holding 2 litres or less",
+          "W200",
+          "Still wine and still fermented beverages other than wine and beer",
+          unitOfMeasureCode = 3
+        ),
+        CnCodeInformation(
+          "27101925",
+          "Other kerosene",
+          "E450",
+          "Kerosene, falling within CN code 2710 19 21 and unmarked kerosene falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        ),
+        CnCodeInformation(
+          "27101925",
+          "Other kerosene",
+          "E460",
+          "Kerosene, marked falling within CN code 2710 19 25 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        ),
+        CnCodeInformation(
+          "27101944",
+          "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+          "E430",
+          "Gasoil, unmarked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        ),
+        CnCodeInformation(
+          "27101944",
+          "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+          "E440",
+          "Gasoil, marked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+          unitOfMeasureCode = 2
+        )
+      )
+
+      repository.collection.insertMany(codeListEntries).toFuture().futureValue
+
+      val cnCodes = withClientSession(repository.buildCnCodes).futureValue
+
+      cnCodes should contain theSameElementsAs expectedCnCodes
     }
 
     "combine together entries of the excise products and product categories codelists" in {

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/CodeListsRepositorySpec.scala
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.emcstfereferencedata.repositories
 
 import org.mongodb.scala.*
-import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepositorySpec.scala
@@ -43,6 +43,47 @@ class ExciseProductsRepositorySpec
 
   private val testProducts = List(testExciseProduct1, testExciseProduct2)
 
+
+  private val testExciseProduct3 = ExciseProductCode(
+    code = "B000",
+    description = "Beer",
+    category = "B",
+    categoryDescription = "Beer"
+  )
+
+  private val testExciseProduct4 = ExciseProductCode(
+    code = "E200",
+    description =
+      "Vegetable and animal oils Products falling within CN codes 1507 to 1518, if these are intended for use as heating fuel or motor fuel (Article 20(1)(a))",
+    category = "E",
+    categoryDescription = "Energy Products"
+  )
+
+  private val testExciseProduct5 = ExciseProductCode(
+    code = "E300",
+    description =
+      "Mineral oils Products falling within CN codes 2707 10, 2707 20, 2707 30 and 2707 50 (Article 20(1)(b))",
+    category = "E",
+    categoryDescription = "Energy Products"
+  )
+
+  private val testExciseProduct6 = ExciseProductCode(
+    code = "W200",
+    description = "Still wine and still fermented beverages other than wine and beer",
+    category = "W",
+    categoryDescription = "Wine and fermented beverages other than wine and beer"
+  )
+
+
+  val exciseProductsListSorted: Seq[ExciseProductCode] = Seq(
+    testExciseProduct3,
+    testExciseProduct4,
+    testExciseProduct5,
+    testExciseProduct1,
+    testExciseProduct2,
+    testExciseProduct6
+  )
+
   "ExciseProductsRepository.fetchExciseProductsForCategory" should {
     "return matching excise products for a given excise product category code" in {
       repository.collection.insertMany(testProducts).toFuture().futureValue
@@ -147,6 +188,16 @@ class ExciseProductsRepositorySpec
       val insertedEntries = findAll().futureValue
 
       insertedEntries should contain theSameElementsAs newProducts
+    }
+  }
+  "ExciseProductsRepository.fetchAllEPCCodes" should {
+    "return all excise products in the database" in {
+      repository.collection.insertMany(exciseProductsListSorted).toFuture().futureValue
+
+      repository
+        .fetchAllEPCCodes()
+        .futureValue should contain theSameElementsInOrderAs exciseProductsListSorted
+
     }
   }
 }

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/repositories/ExciseProductsRepositorySpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.repositories
+
+import org.mongodb.scala.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ExciseProductCode}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import scala.concurrent.ExecutionContext
+
+class ExciseProductsRepositorySpec
+  extends AnyWordSpec
+  with DefaultPlayMongoRepositorySupport[ExciseProductCode]
+  with Matchers
+  with ScalaFutures
+  with BaseFixtures
+  with Transactions {
+
+  given TransactionConfiguration = TransactionConfiguration.strict
+  given ec: ExecutionContext     = ExecutionContext.global
+
+  override protected val repository: ExciseProductsRepository =
+    new ExciseProductsRepository(mongoComponent)
+
+  private val testProducts = List(testExciseProduct1, testExciseProduct2)
+
+  "ExciseProductsRepository.fetchExciseProductsForCategory" should {
+    "return matching excise products for a given excise product category code" in {
+      repository.collection.insertMany(testProducts).toFuture().futureValue
+
+      repository
+        .fetchExciseProductsForCategory("S")
+        .futureValue should contain only testExciseProduct1
+
+      repository
+        .fetchExciseProductsForCategory("T")
+        .futureValue should contain only testExciseProduct2
+    }
+  }
+
+  "ExciseProductsRepository.deleteExciseProducts" should {
+    "delete all excise products from the underlying collection" in {
+      repository.collection.insertMany(testProducts).toFuture().futureValue
+
+      withSessionAndTransaction(repository.deleteExciseProducts).futureValue
+      repository.fetchExciseProductsForCategory("S").futureValue shouldBe empty
+      repository.fetchExciseProductsForCategory("T").futureValue shouldBe empty
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/support/OracleDb.java
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/support/OracleDb.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.support;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.*;
+
+@TagAnnotation
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface OracleDb {
+}

--- a/it/test/uk/gov/hmrc/emcstfereferencedata/support/TestDatabase.scala
+++ b/it/test/uk/gov/hmrc/emcstfereferencedata/support/TestDatabase.scala
@@ -17,12 +17,14 @@
 package test.uk.gov.hmrc.emcstfereferencedata.support
 
 import play.api.libs.ws.writeableOf_String
+import uk.gov.hmrc.emcstfereferencedata.support.OracleDb
 
 import java.net.ConnectException
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
+@OracleDb
 trait TestDatabase {
   this: IntegrationBaseSpec =>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,6 +6,7 @@ object AppDependencies {
   val playSuffix        = "-play-30"
 
   val hmrcBootstrapVersion = "9.13.0"
+  val hmrcMongoVersion     = "2.6.0"
   val scalamockVersion     = "7.3.2"
   val catsCoreVersion      = "2.13.0"
   val oraVersion           = "19.3.0.0"
@@ -13,6 +14,7 @@ object AppDependencies {
 
   private val compile = Seq(
     "uk.gov.hmrc"               %% s"bootstrap-backend$playSuffix"    % hmrcBootstrapVersion,
+    "uk.gov.hmrc.mongo"         %% s"hmrc-mongo$playSuffix"           % hmrcMongoVersion,
     "com.oracle.jdbc"           %   "ojdbc8"                          % oraVersion,
     "com.oracle.jdbc"           %   "orai18n"                         % oraVersion,
     "org.typelevel"             %%  "cats-core"                       % catsCoreVersion,
@@ -22,13 +24,15 @@ object AppDependencies {
 
   private val test = Seq(
     "uk.gov.hmrc"               %% s"bootstrap-test$playSuffix"       % hmrcBootstrapVersion,
+    "uk.gov.hmrc.mongo"         %% s"hmrc-mongo-test$playSuffix"      % hmrcMongoVersion,
     "org.scalamock"             %% "scalamock"                        % scalamockVersion,
     "org.jsoup"                 % "jsoup"                             % jsoupVersion,
   ).map(_ % Test)
 
   val it: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% s"bootstrap-test$playSuffix" % hmrcBootstrapVersion % Test
-  )
+    "uk.gov.hmrc" %% s"bootstrap-test$playSuffix" % hmrcBootstrapVersion,
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test$playSuffix" % hmrcMongoVersion
+  ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test
 

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
@@ -22,9 +22,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
-import uk.gov.hmrc.emcstfereferencedata.models.response.CnCodeInformation
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ErrorResponse}
 import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
 import uk.gov.hmrc.http.HeaderCarrier
+
 import scala.concurrent.Future
 
 class RetrieveAllCNCodesConnectorCRDLSpec
@@ -55,6 +56,16 @@ class RetrieveAllCNCodesConnectorCRDLSpec
 
         connector.retrieveAllCnCodes("doesn't exist").map(_ shouldBe Right(Seq.empty))
 
+      }
+    }
+    "return an Error Response" when {
+      "there is a error fetching data" in {
+        when(repository.fetchCnCodesForProduct(any()))
+          .thenReturn(Future.failed(new RuntimeException("Simulated failure")))
+
+        connector
+          .retrieveAllCnCodes(testCnCode1)
+          .map(_ shouldBe Left(ErrorResponse.UnexpectedDownstreamResponseError))
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -57,8 +58,8 @@ class RetrieveAllCNCodesConnectorCRDLSpec
 
       }
     }
-    "return an Error Response" when {
-      "there is a error fetching data" in {
+    "when there is an error fetching data" should {
+      "return an error response" in {
         when(repository.fetchCnCodesForProduct(any()))
           .thenReturn(Future.failed(new RuntimeException("Simulated failure")))
 

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllCNCodes/RetrieveAllCNCodesConnectorCRDLSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllCNCodes
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.response.CnCodeInformation
+import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.http.HeaderCarrier
+import scala.concurrent.Future
+
+class RetrieveAllCNCodesConnectorCRDLSpec
+  extends AsyncWordSpec
+  with Matchers
+  with MockitoSugar
+  with BaseFixtures {
+
+  private val repository = mock[CnCodesRepository]
+  private val connector  = new RetrieveAllCNCodesConnectorCRDL(repository)
+
+  given HeaderCarrier = HeaderCarrier()
+
+  "RetrieveAllCNCodesConnectorCRDL.retrieveAllCnCodes" when {
+    "given an excise product code" should {
+      "return a list of CN Code information" in {
+        when(repository.fetchCnCodesForProduct(any()))
+          .thenReturn(Future.successful(Seq(testCnCodeInformation1)))
+
+        connector.retrieveAllCnCodes("T400").map(_ shouldBe Right(Seq(testCnCodeInformation1)))
+
+      }
+    }
+
+    "given an invalid excise product code " should {
+      "return a empty list" in {
+        when(repository.fetchCnCodesForProduct(any())).thenReturn(Future.successful(Seq.empty))
+
+        connector.retrieveAllCnCodes("doesn't exist").map(_ shouldBe Right(Seq.empty))
+
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDLSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes
+
+import org.mockito.ArgumentMatchers.any
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.response.{ErrorResponse, ExciseProductCode}
+import uk.gov.hmrc.emcstfereferencedata.repositories.ExciseProductsRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class RetrieveAllEPCCodesConnectorCRDLSpec
+  extends AsyncWordSpec
+  with Matchers
+  with MockitoSugar
+  with BaseFixtures {
+
+  private val repository = mock[ExciseProductsRepository]
+  private val connector  = new RetrieveAllEPCCodesConnectorCRDL(repository)
+
+  given HeaderCarrier = HeaderCarrier()
+
+  val exciseItemsList = Seq(
+    ExciseProductCode(
+      code = "W200",
+      description = "Still wine and still fermented beverages other than wine and beer",
+      category = "W",
+      categoryDescription = "Wine and fermented beverages other than wine and beer"
+    ),
+    ExciseProductCode(
+      code = "B000",
+      description = "Beer",
+      category = "B",
+      categoryDescription = "Beer"
+    ),
+    ExciseProductCode(
+      code = "E200",
+      description =
+        "Vegetable and animal oils Products falling within CN codes 1507 to 1518, if these are intended for use as heating fuel or motor fuel (Article 20(1)(a))",
+      category = "E",
+      categoryDescription = "Energy Products"
+    ),
+    ExciseProductCode(
+      code = "E300",
+      description =
+        "Mineral oils Products falling within CN codes 2707 10, 2707 20, 2707 30 and 2707 50 (Article 20(1)(b))",
+      category = "W" +
+        "E",
+      categoryDescription = "Energy Products"
+    )
+  )
+
+  "RetrieveAllEPCCodesConnectorCRDL.retrieveAllEPCCodes" should {
+    "Return a Map of Cncode to CnCodeInformation " in {
+      when(repository.fetchAllEPCCodes())
+        .thenReturn(
+          Future.successful(exciseItemsList)
+        )
+
+      connector.retrieveAllEPCCodes()
+        .map(
+          _ shouldBe Right(exciseItemsList)
+        )
+    }
+
+    "Return an empty list" when {
+      "there are no Excise items in the database" in {
+        when(repository.fetchAllEPCCodes())
+          .thenReturn(Future.successful(Seq.empty))
+
+        connector.retrieveAllEPCCodes()
+          .map(_ shouldBe Right(Seq.empty))
+
+      }
+    }
+    "return an Error Response" when {
+      "there is a error fetching data" in {
+        when(repository.fetchAllEPCCodes())
+          .thenReturn(Future.failed(new RuntimeException("Simulated failure")))
+
+        connector.retrieveAllEPCCodes()
+          .map(_ shouldBe Left(ErrorResponse.UnexpectedDownstreamResponseError))
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveAllEPCCodes/RetrieveAllEPCCodesConnectorCRDLSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.emcstfereferencedata.connector.retrieveAllEPCCodes
 
-import org.mockito.ArgumentMatchers.any
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import org.mockito.Mockito.when
@@ -39,7 +38,7 @@ class RetrieveAllEPCCodesConnectorCRDLSpec
 
   given HeaderCarrier = HeaderCarrier()
 
-  val exciseItemsList = Seq(
+  val exciseProductsList: Seq[ExciseProductCode] = Seq(
     ExciseProductCode(
       code = "W200",
       description = "Still wine and still fermented beverages other than wine and beer",
@@ -63,22 +62,22 @@ class RetrieveAllEPCCodesConnectorCRDLSpec
       code = "E300",
       description =
         "Mineral oils Products falling within CN codes 2707 10, 2707 20, 2707 30 and 2707 50 (Article 20(1)(b))",
-      category = "W" +
-        "E",
+      category = "E",
       categoryDescription = "Energy Products"
     )
   )
 
   "RetrieveAllEPCCodesConnectorCRDL.retrieveAllEPCCodes" should {
-    "Return a Map of Cncode to CnCodeInformation " in {
+    "Return a Sequence of all excise products" in {
       when(repository.fetchAllEPCCodes())
         .thenReturn(
-          Future.successful(exciseItemsList)
+          Future.successful(exciseProductsList)
         )
 
-      connector.retrieveAllEPCCodes()
+      connector
+        .retrieveAllEPCCodes()
         .map(
-          _ shouldBe Right(exciseItemsList)
+          _ shouldBe Right(exciseProductsList)
         )
     }
 
@@ -87,7 +86,8 @@ class RetrieveAllEPCCodesConnectorCRDLSpec
         when(repository.fetchAllEPCCodes())
           .thenReturn(Future.successful(Seq.empty))
 
-        connector.retrieveAllEPCCodes()
+        connector
+          .retrieveAllEPCCodes()
           .map(_ shouldBe Right(Seq.empty))
 
       }
@@ -97,7 +97,8 @@ class RetrieveAllEPCCodesConnectorCRDLSpec
         when(repository.fetchAllEPCCodes())
           .thenReturn(Future.failed(new RuntimeException("Simulated failure")))
 
-        connector.retrieveAllEPCCodes()
+        connector
+          .retrieveAllEPCCodes()
           .map(_ shouldBe Left(ErrorResponse.UnexpectedDownstreamResponseError))
       }
     }

--- a/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDLSpec.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/connector/retrieveCnCodeInformation/RetrieveCnCodeInformationConnectorCRDLSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfereferencedata.connector.retrieveCnCodeInformation
+
+import org.mockito.ArgumentMatchers.any
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.emcstfereferencedata.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfereferencedata.models.request.{CnInformationItem, CnInformationRequest}
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, ErrorResponse}
+import uk.gov.hmrc.emcstfereferencedata.repositories.CnCodesRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class RetrieveCnCodeInformationConnectorCRDLSpec
+  extends AsyncWordSpec
+  with Matchers
+  with MockitoSugar
+  with BaseFixtures {
+
+  private val repository               = mock[CnCodesRepository]
+  private val codeInformationConnector = new RetrieveCnCodeInformationConnectorCRDL(repository)
+
+  given HeaderCarrier = HeaderCarrier()
+
+  "RetrieveCnCodeInformationConnectorCRDL.retrieveCnCodeInformation" when {
+    "Given a List of CnInformation Items, each with a product code and excise code" should {
+      "Return a Map of Cncode to CnCodeInformation " in {
+        when(repository.fetchCnCodeInformation(any()))
+          .thenReturn(
+            Future.successful(
+              Map(testCnCode1 -> testCnCodeInformation1, testCnCode2 -> testCnCodeInformation2)
+            )
+          )
+
+        codeInformationConnector
+          .retrieveCnCodeInformation(
+            testCnCodeInformationRequest
+          )
+          .map(
+            _ shouldBe Right(
+              Map(testCnCode1 -> testCnCodeInformation1, testCnCode2 -> testCnCodeInformation2)
+            )
+          )
+      }
+
+    }
+    "given an invalid excise code to CnCode combination" should {
+      "Return an empty Map" in {
+        when(repository.fetchCnCodeInformation(any()))
+          .thenReturn(Future.successful(Map.empty))
+
+        codeInformationConnector
+          .retrieveCnCodeInformation(
+            CnInformationRequest(List(CnInformationItem("M400", "invalid")))
+          )
+          .map(_ shouldBe Right(Map.empty))
+
+      }
+    }
+    "return an Error Response" when {
+      "there is a error fetching data" in {
+        when(repository.fetchCnCodeInformation(any()))
+          .thenReturn(Future.failed(new RuntimeException("Simulated failure")))
+
+        codeInformationConnector
+          .retrieveCnCodeInformation(testCnCodeInformationRequest)
+          .map(_ shouldBe Left(ErrorResponse.UnexpectedDownstreamResponseError))
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfereferencedata/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/fixtures/BaseFixtures.scala
@@ -45,6 +45,34 @@ trait BaseFixtures {
     exciseProductCodeDescription = "Other products containing ethyl alcohol",
     unitOfMeasureCode = 3
   )
+  val testCnCodeInformation3: CnCodeInformation = CnCodeInformation(
+    cnCode = "27101944",
+    cnCodeDescription = "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+    exciseProductCode = "E430",
+    exciseProductCodeDescription = "Gasoil, unmarked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+    unitOfMeasureCode = 2
+  )
+  val testCnCodeInformation4: CnCodeInformation = CnCodeInformation(
+    cnCode = "27101944",
+    cnCodeDescription = "Other heavy gas oils for other purposes with a sulphur content not exceeding 0,001% by weight.",
+    exciseProductCode = "E440",
+    exciseProductCodeDescription = "Gasoil, marked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+    unitOfMeasureCode = 2
+  )
+  val testCnCodeInformation5: CnCodeInformation = CnCodeInformation(
+    cnCode = "27102019",
+    cnCodeDescription = "Gas oil with a sulphur content exceeding 0.1% by weight, containing biodiesel",
+    exciseProductCode = "E430",
+    exciseProductCodeDescription = "Gasoil, unmarked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+    unitOfMeasureCode = 2
+  )
+  val testCnCodeInformation6: CnCodeInformation = CnCodeInformation(
+    cnCode = "27102019",
+    cnCodeDescription = "Gas oil with a sulphur content exceeding 0.1% by weight, containing biodiesel",
+    exciseProductCode = "E440",
+    exciseProductCodeDescription = "Gasoil, marked falling within CN codes 2710 19 42, 2710 19 44, 2710 19 46, 2710 19 47, 2710 19 48, 2710 20 11, 2710 20 16 and 2710 20 19 (Article 20(1)(c) of Directive 2003/96/EC)",
+    unitOfMeasureCode = 2
+  )
   val testExciseProduct1: ExciseProductCode = ExciseProductCode(
     code = "S500",
     description = "Other products containing ethyl alcohol",

--- a/test/uk/gov/hmrc/emcstfereferencedata/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfereferencedata/fixtures/BaseFixtures.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.emcstfereferencedata.fixtures
 
 import uk.gov.hmrc.emcstfereferencedata.models.request.{CnInformationItem, CnInformationRequest}
-import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, Country, TraderKnownFacts}
+import uk.gov.hmrc.emcstfereferencedata.models.response.{CnCodeInformation, Country, ExciseProductCode, TraderKnownFacts}
 
 trait BaseFixtures {
 
@@ -44,6 +44,18 @@ trait BaseFixtures {
     exciseProductCode = "S500",
     exciseProductCodeDescription = "Other products containing ethyl alcohol",
     unitOfMeasureCode = 3
+  )
+  val testExciseProduct1: ExciseProductCode = ExciseProductCode(
+    code = "S500",
+    description = "Other products containing ethyl alcohol",
+    category = "S",
+    categoryDescription = "Ethyl alcohol and spirits"
+  )
+  val testExciseProduct2: ExciseProductCode = ExciseProductCode(
+    code = "T400",
+    description = "Fine-cut tobacco for the rolling of cigarettes",
+    category = "T",
+    categoryDescription = "Manufactured tobacco products"
   )
   val testWineOperations: Seq[String] = Seq(
     "4",


### PR DESCRIPTION
This draft PR contains the work needed to integrate the EMCS TFE reference data service with the CRDL reference data cache.

- [X] Set up MongoDB connectivity
- [x] Create models for the CRDL cache responses
- [x] Implement a repository for codelist entries
- [x] Implement a repository for excise products
- [x] Implement a repository for CN code information
- [x] Implement a Mongo aggregation which turns codelist entries into excise products
- [x] Implement a Mongo aggregation which turns codelist entries into CN code information
- [x] Add a connector that calls the CRDL cache service to fetch codelists
- [ ] Implement a daily migration job which rebuilds the excise products and CN code information collections
- [ ] Add a test-only endpoint which triggers the daily import job
- [x] Add test-only endpoints which clear each of the Mongo collections
- [x] Implement a CRDL connector for the retrieveAllCNCodes procedure
- [x] Implement a CRDL connector for the retrieveAllEPCCodes procedure
- [x] Implement a CRDL connector for the retrieveCNCodeInformation procedure
- [ ] Implement a CRDL connector for the retrieveOtherReferenceData procedure
- [ ] Implement a CRDL connector for the retrievePackagingTypes procedure
- [ ] Implement a CRDL connector for the retrieveProductCodes procedure
- [ ] Add a feature flag to the app configuration to switch over to the CRDL connector implementations